### PR TITLE
modified:   simple-map.php

### DIFF
--- a/simple-map.php
+++ b/simple-map.php
@@ -34,7 +34,7 @@ public function init()
 
     wp_embed_register_handler(
         'google-map',
-        '#(https://maps.google.co.jp/maps(/ms)?\?.+)#i',
+        '#(https://(www|maps).google.[a-z]{2,3}\.?[a-z]{0,3}/maps(/ms)?\?.+)#i',
         array(&$this, 'oembed_handler')
     );
 }


### PR DESCRIPTION
   change URL match pattern for legacy sub-domain? and more Google
   domains

google mapのURLのsub-domainがwwwとmapsがあるので追加し、ついでに各国のgoogle domainも対応できるようにしました。
よかったら、マージお願いします。

Google Domains
http://en.wikipedia.org/wiki/List_of_Google_domains
