### PR TITLE
remove sensor parameter, because it is not used any more.

### DIFF
--- a/js/simple-map.js
+++ b/js/simple-map.js
@@ -93,8 +93,7 @@ SimpleMap.prototype.display = function( element, pos, zoom, infoCont ) {
 			size: breakpoint + 'x' + $( element ).height(),
 			markers: [
 				{lat: pos.lat(), lng: pos.lng()}
-			],
-			sensor: 'false'
+			]
 		} );
 		var img = $( '<img />' );
 		$( img ).attr( 'src', url );


### PR DESCRIPTION
When rendering with phones, sensor=false is added, but it's not valid or necessary anymore.
We get an error message like below.

Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

