### PR TITLE
Use "key" shortcode tag to provide Google Maps API key.

### DIFF
--- a/js/simple-map.js
+++ b/js/simple-map.js
@@ -96,7 +96,7 @@ SimpleMap.prototype.display = function( element, pos, zoom, infoCont ) {
 			]
 		} );
 		var img = $( '<img />' );
-		$( img ).attr( 'src', url );
+		$( img ).attr( 'src', url + simplemap.key );
 		$( img ).attr( 'alt', $( element ).text() );
 		var a = $( '<a />' );
 		$( a ).attr(

--- a/simple-map.php
+++ b/simple-map.php
@@ -21,6 +21,7 @@ class Simple_Map {
 	private $zoom           = 16;
 	private $breakpoint     = 480;
 	private $max_breakpoint = 640;
+	private $gmaps_key      = null;
 
 	function __construct()
 	{
@@ -55,9 +56,10 @@ class Simple_Map {
 
 	public function wp_enqueue_scripts()
 	{
+		$this->gmaps_key = apply_filters( 'simplemap_gmaps_key', $this->gmaps_key );
 		wp_register_script(
 			'google-maps-api',
-			'//maps.google.com/maps/api/js',
+			'//maps.google.com/maps/api/js' . ((isset($this->gmaps_key)) ? '?key='.$this->gmaps_key : ''),
 			false,
 			null,
 			true
@@ -74,10 +76,18 @@ class Simple_Map {
 			true
 		);
 		wp_enqueue_script( 'simplemap' );
+
+		wp_localize_script( 'simplemap', 'simplemap', array(
+			'key' => '&key='.$this->gmaps_key
+		));
+
 	}
 
 	public function shortcode( $p, $content = null )
 	{
+		if ( isset( $p['key'] ) && $p['key'] ) {
+			$this->gmaps_key = $p['key'];
+		}
 		add_action( 'wp_footer', array( &$this, 'wp_enqueue_scripts' ) );
 
 		if ( isset( $p['width'] ) && preg_match( '/^[0-9]+(%|px)$/', $p['width'] ) ) {


### PR DESCRIPTION
I decided to go a different route from marushu's pull request. To keep the plugin "simple" I enabled a "key" tag to the shortcode. This parameter will be the Google Maps API key.

The API key must have Google Static Maps API and Google Maps JavaScript API enabled.

I used wp_localize_script to pass the key to the simple-map.js script for use when a static map is used. I add the key to the image url because it was not accepted by the GMaps.staticMapURL constructor.